### PR TITLE
fix: docker-compose.yml mysql_5 service - command 수정

### DIFF
--- a/shop/docker-compose.yml
+++ b/shop/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     command:
       - "mysqld"
       - "--character-set-server=utf8mb4"
+      - "--lower_case_table_names=1"
       - "--collation-server=utf8mb4_unicode_ci"
     networks:
       - default_network


### PR DESCRIPTION
쿼리 시 테이블 명 대소문자 구분 해제